### PR TITLE
test: refresh MiniMax model fixtures to M3

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,7 +25,7 @@ class TestMiniMaxProxyIntegration:
         """A request with /minimax/ prefix should be routed to api.minimax.io."""
         body = json.dumps(
             {
-                "model": "MiniMax-M2.5",
+                "model": "MiniMax-M3",
                 "messages": [{"role": "user", "content": "hello"}],
             }
         ).encode()
@@ -41,7 +41,7 @@ class TestMiniMaxProxyIntegration:
         self.proxy._process_request(body, cleaned, provider)
         assert len(self.events) == 1
         assert self.events[0]["provider"] == "minimax"
-        assert self.events[0]["model"] == "MiniMax-M2.5"
+        assert self.events[0]["model"] == "MiniMax-M3"
 
     @pytest.mark.asyncio
     async def test_openai_not_affected_by_minimax(self):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -100,7 +100,7 @@ class TestProcessRequest:
 
     def test_minimax_request_parsed_as_openai_compat(self):
         body = {
-            "model": "MiniMax-M2.5",
+            "model": "MiniMax-M3",
             "messages": [
                 {"role": "user", "content": "Hello MiniMax"},
             ],
@@ -112,7 +112,7 @@ class TestProcessRequest:
         )
         assert len(self.events) == 1
         assert self.events[0]["provider"] == "minimax"
-        assert self.events[0]["model"] == "MiniMax-M2.5"
+        assert self.events[0]["model"] == "MiniMax-M3"
         assert self.events[0]["tokens"] > 0
 
     def test_minimax_multimodal_content(self):
@@ -137,7 +137,7 @@ class TestProcessRequest:
 
     def test_minimax_system_message(self):
         body = {
-            "model": "MiniMax-M2.5",
+            "model": "MiniMax-M3",
             "messages": [
                 {"role": "system", "content": "You are helpful"},
                 {"role": "user", "content": "Hi"},
@@ -155,7 +155,7 @@ class TestProcessRequest:
 
     def test_minimax_no_callback_no_error(self):
         proxy = ProxyServer(port=9999, on_request=None)
-        body = {"model": "MiniMax-M2.5", "messages": []}
+        body = {"model": "MiniMax-M3", "messages": []}
         # Should not raise
         proxy._process_request(
             json.dumps(body).encode(),


### PR DESCRIPTION
## Summary
Refresh MiniMax model identifiers in test fixtures so the test suite reflects the current flagship model (`MiniMax-M3`).

## Changes
- Replace deprecated `MiniMax-M2.5` references in `tests/test_proxy.py` and `tests/test_integration.py` with `MiniMax-M3`
- Retain existing `MiniMax-M2.7` fixtures to keep coverage for an alternate model identifier

## Why
MiniMax-M3 is the new flagship model (512K context window, 128K max output, image input). Using it as the default sample body keeps the tests aligned with current usage patterns and lightly documents which model the proxy is being exercised against.

The proxy itself is model-agnostic — it forwards whatever model the caller sends in the request body — so this is a fixtures-only change with no behavior impact.

## Testing
- Full test suite passes locally (`pytest tests/`, 38 passed)